### PR TITLE
msm: ipc_socket: fix leak of kernel memory to userspace

### DIFF
--- a/arch/arm/mach-msm/ipc_socket.c
+++ b/arch/arm/mach-msm/ipc_socket.c
@@ -513,16 +513,20 @@ static int msm_ipc_router_ioctl(struct socket *sock,
 			break;
 		}
 		server_arg.num_entries_found = ret;
-
 		ret = copy_to_user((void *)arg, &server_arg,
 				   sizeof(server_arg));
-		if (srv_info_sz) {
+
+		n = min(server_arg.num_entries_found,
+			server_arg.num_entries_in_array);
+
+		if (ret == 0 && n) {
 			ret = copy_to_user((void *)(arg + sizeof(server_arg)),
-					   srv_info, srv_info_sz);
-			if (ret)
-				ret = -EFAULT;
-			kfree(srv_info);
+					   srv_info, n * sizeof (*srv_info));
 		}
+
+		if (ret)
+			ret = -EFAULT;
+		kfree(srv_info);
 		break;
 
 	case IPC_ROUTER_IOCTL_BIND_CONTROL_PORT:


### PR DESCRIPTION
Limit the size of copy to the minimum of what was asked
for or the number of results returned to prevent leaking of
uninitialized kernel memory to userspace.

Bug: 24157888

Signed-off-by: Patrick Tjin <pattjin@google.com>
Change-Id: I7433135ea3345905c053a81d0d759619b46c1430